### PR TITLE
Add setup script for Codespaces

### DIFF
--- a/.antigenrc
+++ b/.antigenrc
@@ -1,0 +1,12 @@
+antigen use oh-my-zsh
+
+antigen bundle git
+antigen bundle fzf
+
+antigen bundle zsh-users/zsh-completions
+antigen bundle zsh-users/zsh-autosuggestions
+antigen bundle zsh-users/zsh-syntax-highlighting
+
+antigen theme theunraveler
+
+antigen apply

--- a/.zshrc
+++ b/.zshrc
@@ -1,0 +1,19 @@
+# exports
+export SHELL=$(which zsh)
+export FZF_DEFAULT_COMMAND='rg --files --hidden'
+
+# aliases
+alias ..="cd .."
+alias ...="cd ../.."
+alias ....="cd ../../.."
+alias .....="cd ../../../.."
+alias ~="cd ~"
+alias -- -="cd -"
+alias sudo='sudo '
+alias ls='ls -GFh'
+alias ll='ls -GFhl'
+alias la='ls -GFhla'
+
+# setup antigen
+source ~/antigen.zsh
+antigen init ~/.antigenrc

--- a/setup
+++ b/setup
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+apt-get update
+apt-get install -y zsh
+chsh -s $(which zsh)
+
+curl -L git.io/antigen > ~/antigen.zsh

--- a/setup
+++ b/setup
@@ -8,3 +8,5 @@ apt-get install ripgrep
 apt-get install fzf
 
 curl -L git.io/antigen > ~/antigen.zsh
+cp ~/dotfiles/.zshrc > ~/.zshrc
+cp ~/dotfiles/.antigenrc > ~/.antigenrc

--- a/setup
+++ b/setup
@@ -4,4 +4,7 @@ apt-get update
 apt-get install -y zsh
 chsh -s $(which zsh)
 
+apt-get install ripgrep
+apt-get install fzf
+
 curl -L git.io/antigen > ~/antigen.zsh


### PR DESCRIPTION
Adds setup script to:

- Install `zsh`
- Set it as the default shell
- Install [`antigen`](https://github.com/zsh-users/antigen)
- Configure `.zshrc`