### PR TITLE
Update editor visibility defaults and skip Codespaces shell change

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cd ~/.dotfiles
 3. **Install apps** on macOS (Chrome, Raycast, Ghostty, Slack, etc.)
 4. **Symlink dotfiles** from `home/` to `$HOME`
 5. **Apply macOS defaults** (Dock, Finder, Keyboard, Screenshots, UX)
-6. **Set zsh as default shell**
+6. **Set zsh as default shell** (skipped in GitHub Codespaces)
 
 ## Commands
 

--- a/home/.config/nvim/lua/plugins/dashboard.lua
+++ b/home/.config/nvim/lua/plugins/dashboard.lua
@@ -2,6 +2,18 @@ return {
   {
     "folke/snacks.nvim",
     opts = {
+      picker = {
+        sources = {
+          files = {
+            hidden = true,
+            ignored = true,
+          },
+          explorer = {
+            hidden = true,
+            ignored = true,
+          },
+        },
+      },
       dashboard = {
         preset = {
           header = [[

--- a/home/.config/nvim/lua/plugins/neo-tree.lua
+++ b/home/.config/nvim/lua/plugins/neo-tree.lua
@@ -1,6 +1,12 @@
 return {
   "nvim-neo-tree/neo-tree.nvim",
   opts = {
+    filesystem = {
+      filtered_items = {
+        hide_dotfiles = false,
+        hide_gitignored = false,
+      },
+    },
     window = {
       mappings = {
         -- Match Telescope keybindings for consistency

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -62,6 +62,10 @@ export PATH="$BUN_INSTALL/bin:$PATH"
 # maestro
 export PATH=$PATH:$HOME/.maestro/bin
 
+# android
+export ANDROID_HOME="$HOME/Library/Android/sdk";
+export PATH="$PATH:$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator"
+
 # Other env vars
 export SHELL=$(which zsh)
 export VISUAL="nvim"

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -26,7 +26,7 @@ var initCmd = &cobra.Command{
   1. Installing packages via Homebrew
   2. Symlinking dotfiles to your home directory
   3. Configuring macOS system settings (macOS only)
-  4. Setting zsh as your default shell`,
+  4. Setting zsh as your default shell (except in GitHub Codespaces)`,
 	RunE: runInit,
 }
 
@@ -79,7 +79,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 
 	ui.PrintHeader("Shell Configuration")
-	if err := configureShell(); err != nil {
+	if err := configureShell(plat); err != nil {
 		ui.PrintWarning(fmt.Sprintf("Could not set default shell: %v", err))
 	}
 
@@ -252,7 +252,12 @@ func configureMacOS() error {
 	return nil
 }
 
-func configureShell() error {
+func configureShell(plat platform.Info) error {
+	if plat.IsCodespaces {
+		ui.PrintInfo("Skipping default shell change in GitHub Codespaces")
+		return nil
+	}
+
 	if packages.IsZshDefault() {
 		ui.PrintSuccess("zsh is already the default shell")
 		return nil


### PR DESCRIPTION
## Summary
- show hidden and gitignored files by default in LazyVim/Snacks picker + explorer
- show dotfiles and gitignored files in neo-tree
- change Ghostty Shift+Enter mapping to plain newline
- skip default shell change in GitHub Codespaces during `dotfiles init`

## Validation
- go test ./...
- go build ./...
- go vet ./...
