### PR TITLE
Update shell and editor dotfiles

### DIFF
--- a/home/.config/nvim/lua/plugins/prisma.lua
+++ b/home/.config/nvim/lua/plugins/prisma.lua
@@ -1,0 +1,10 @@
+return {
+  {
+    "neovim/nvim-lspconfig",
+    opts = {
+      servers = {
+        prismals = {},
+      },
+    },
+  },
+}

--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -27,3 +27,9 @@
   defaultBranch = main
 [pager]
   branch = false
+[credential "https://github.com"]
+  helper =
+  helper = !gh auth git-credential
+[credential "https://gist.github.com"]
+  helper =
+  helper = !gh auth git-credential

--- a/home/.tmux.conf
+++ b/home/.tmux.conf
@@ -55,9 +55,9 @@ set -g @plugin 'christoomey/vim-tmux-navigator'
 
 # Catppuccin configuration
 set -g @catppuccin_flavor 'frappe'
-set -g @catppuccin_window_text " #W"
-set -g @catppuccin_window_default_text " #W"
-set -g @catppuccin_window_current_text " #W"
+set -g @catppuccin_window_text " #{?@copilot_alert,#{@copilot_alert} ,}#W"
+set -g @catppuccin_window_default_text " #{?@copilot_alert,#{@copilot_alert} ,}#W"
+set -g @catppuccin_window_current_text " #{?@copilot_alert,#{@copilot_alert} ,}#W"
 
 ################################################################################
 #                                 Appearance
@@ -69,6 +69,9 @@ set -g status-right " #[fg=#{@thm_crust},bg=#{@thm_teal}] #h "
 
 # Ensure that everything on the left side of the status line is included.
 set -g status-left-length 100
+
+# Clear Copilot hook alerts when switching to the marked window.
+set-hook -g after-select-window[50] 'set-option -wq @copilot_alert ""'
 
 ################################################################################
 #                              TPM Bootstrap

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -329,3 +329,9 @@ if [ -f "$HOME/.zshrc.local" ]; then
   source "$HOME/.zshrc.local"
 fi
 
+
+# The next line updates PATH for the Google Cloud SDK.
+if [ -f "$HOME/google-cloud-sdk/path.zsh.inc" ]; then . "$HOME/google-cloud-sdk/path.zsh.inc"; fi
+
+# The next line enables shell command completion for gcloud.
+if [ -f "$HOME/google-cloud-sdk/completion.zsh.inc" ]; then . "$HOME/google-cloud-sdk/completion.zsh.inc"; fi


### PR DESCRIPTION
## Summary
- show Copilot tmux alerts in Catppuccin window titles and clear them after selecting a window
- configure GitHub and gist credential helpers through gh without a machine-specific binary path
- load Google Cloud SDK shell integration from $HOME when installed
- add Prisma LSP support to Neovim

## Validation
- zsh -n home/.zshrc
- git config --file home/.gitconfig --list
- tmux source-file home/.tmux.conf
- nvim --headless Lua syntax check
- git diff --check